### PR TITLE
Update deprecated add-skill command to skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Skills are invoked automatically by your AI assistant when relevant. You can als
 - "Use the mapbox-web-performance-patterns skill to optimize this"
 - "Check the mapbox-token-security skill for best practices"
 
-Install skills: `npx add-skill mapbox/mapbox-agent-skills`
+Install skills: `npx skills add mapbox/mapbox-agent-skills`
 
 ## Skill Combinations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Before submitting:
    ```
 
 5. **Test with AI assistant:**
-   - Install locally: `npx add-skill . -a claude-code` (or your AI assistant)
+   - Install locally: `npx skills add . -a claude-code` (or your AI assistant)
    - Ask questions the skill should help with
    - Verify the AI uses the skill appropriately
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 Install all Mapbox Agent Skills:
 
 ```bash
-npx add-skill mapbox/mapbox-agent-skills
+npx skills add mapbox/mapbox-agent-skills
 ```
 
 Install specific skills:
 
 ```bash
-npx add-skill mapbox/mapbox-agent-skills --skill mapbox-web-performance-patterns
+npx skills add mapbox/mapbox-agent-skills --skill mapbox-web-performance-patterns
 ```
 
 List available skills:
 
 ```bash
-npx add-skill mapbox/mapbox-agent-skills --list
+npx skills add mapbox/mapbox-agent-skills --list
 ```
 
 > **💡 Pro tip:** These skills work great on their own, but they're even more powerful when combined with the [Mapbox MCP DevKit Server](https://github.com/mapbox/mcp-devkit-server). Skills provide the expertise (performance patterns, design principles), while MCP tools provide the actions (create styles, generate previews). Together, they enable complete workflows from design to deployment.
@@ -527,7 +527,7 @@ Skills in this repository are automatically discovered by Claude Code when place
 
 ```bash
 # Install all skills
-npx add-skill mapbox/mapbox-agent-skills
+npx skills add mapbox/mapbox-agent-skills
 
 # Or manually symlink (for development)
 mkdir -p .claude
@@ -539,18 +539,18 @@ Skills are automatically activated when relevant to your task.
 ### With Cursor
 
 ```bash
-npx add-skill mapbox/mapbox-agent-skills -a cursor
+npx skills add mapbox/mapbox-agent-skills -a cursor
 ```
 
 ### With VS Code (GitHub Copilot)
 
 ```bash
-npx add-skill mapbox/mapbox-agent-skills -a vscode
+npx skills add mapbox/mapbox-agent-skills -a vscode
 ```
 
 ### With Other AI Assistants
 
-The `add-skill` CLI supports: OpenCode, Codex, Antigravity, and more. Run `npx add-skill --help` for full list.
+The `skills` CLI supports: OpenCode, Codex, Antigravity, and more. Run `npx skills add --help` for full list.
 
 ## Example Usage
 
@@ -741,7 +741,7 @@ git clone https://github.com/mapbox/mapbox-agent-skills.git
 cd mapbox-agent-skills
 
 # Install in Claude Code
-npx add-skill . -a claude-code
+npx skills add . -a claude-code
 
 # Or symlink for development
 mkdir -p .claude
@@ -777,7 +777,7 @@ Test with prompts like:
 
 - [Agent Skills Overview](https://agentskills.io)
 - [Agent Skills Specification](https://github.com/anthropics/skills)
-- [add-skill CLI Tool](https://add-skill.org/)
+- [Skills CLI Tool](https://github.com/anthropics/skills)
 
 **Mapbox Documentation:**
 


### PR DESCRIPTION
## Summary

The `add-skill` package has been deprecated and renamed to `skills`. This PR updates all documentation to use the new command format.

## Changes

- ✅ Updated all `npx add-skill` → `npx skills add` commands
- ✅ Updated CLI reference from `add-skill` → `skills`
- ✅ Updated documentation link to point to correct repository

## Files Modified

- `README.md` - Installation commands, CLI references, and documentation links
- `CONTRIBUTING.md` - Testing instructions
- `AGENTS.md` - Installation command

## Testing

All changes are documentation-only. Verified the new command works:
```bash
npx skills add mapbox/mapbox-agent-skills
```

## Context

Users were seeing deprecation warnings:
```
npm warn deprecated add-skill@2.0.0: This package has been renamed to 'skills'. 
Use 'npx skills add' instead.
```

This PR fixes the documentation to match the current package name.