### PR TITLE
Add GL JS team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @mapbox/locationai
+
+* /examples/web/** @mapbox/gl-js
+* /skills/mapbox-web-integration-patterns/** @mapbox/gl-js
+* /skills/mapbox-web-performance-patterns/** @mapbox/gl-js


### PR DESCRIPTION
## Description

<!-- Provide a clear explanation of what has been added or changed. -->

Adds @mapbox/gl-js team as a codeowner for related skills. This also requires adding @mapbox/gl-js team to the https://github.com/mapbox/mapbox-agent-skills/settings/access with Write access.

---

## Type of Change

<!-- Check the type that applies to this PR -->

- [x] Repository maintenance (CI, tooling, etc.)
