### PR TITLE
Fix broken simplestatistics.org link

### DIFF
--- a/skills/mapbox-data-visualization-patterns/SKILL.md
+++ b/skills/mapbox-data-visualization-patterns/SKILL.md
@@ -1133,5 +1133,5 @@ map.addLayer({
 - [Mapbox Expression Reference](https://docs.mapbox.com/style-spec/reference/expressions/)
 - [ColorBrewer](https://colorbrewer2.org/) - Color scales for maps
 - [Turf.js](https://turfjs.org/) - Spatial analysis
-- [Simple Statistics](https://simplestatistics.org/) - Data classification
+- [Simple Statistics](https://simple-statistics.github.io/) - Data classification
 - [Data Visualization Tutorials](https://docs.mapbox.com/help/tutorials/#data-visualization)


### PR DESCRIPTION
## Summary

- `simplestatistics.org` has been domain-squatted and now redirects to `group70int.com`, causing the link checker to fail with a 308 error on all PRs
- Replaced with the current Simple Statistics GitHub Pages URL: `https://simple-statistics.github.io/`

This is a hotfix to unblock all open PRs from CI failures on this link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)