### PR TITLE
Add Claude plugin manifest and MCP server config

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "mapbox",
+  "version": "1.0.0",
+  "description": "Mapbox skills and MCP servers for building location-aware applications with AI. Includes geospatial tools, style management, and patterns for web, iOS, Android, and AI agent frameworks.",
+  "author": {
+    "name": "Mapbox",
+    "url": "https://mapbox.com"
+  },
+  "homepage": "https://github.com/mapbox/mapbox-agent-skills",
+  "repository": "https://github.com/mapbox/mapbox-agent-skills",
+  "license": "MIT",
+  "keywords": ["mapbox", "maps", "geospatial", "location", "mcp", "gis"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mapbox-devkit": {
+      "url": "https://mcp-devkit.mapbox.com/mcp"
+    },
+    "mapbox": {
+      "url": "https://mcp.mapbox.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` manifest to package this repository as an installable Claude plugin
- Adds `.mcp.json` with both hosted Mapbox MCP servers (DevKit and Runtime)

## Details

The plugin manifest follows the [claude-plugins-official](https://github.com/anthropics/claude-plugins-official) format:

- **Plugin name:** `mapbox`
- **Skills:** Auto-discovered from `./skills/` directory (all 17 existing skills)
- **MCP servers:** Both hosted servers with OAuth support
  - `mapbox-devkit` → `https://mcp-devkit.mapbox.com/mcp`
  - `mapbox` → `https://mcp.mapbox.com/mcp`

Skills are namespaced as `/mapbox:<skill-name>` when installed.

## Test plan

- [ ] Verify `.claude-plugin/plugin.json` is valid JSON
- [ ] Verify `.mcp.json` is valid JSON with correct server URLs
- [ ] Confirm plugin can be installed and skills are discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)