### PR TITLE
Add evals for mapbox-data-visualization-patterns

### DIFF
--- a/skills/mapbox-data-visualization-patterns/evals/evals.json
+++ b/skills/mapbox-data-visualization-patterns/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "skill_name": "mapbox-data-visualization-patterns",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm building a choropleth map showing US population by state. States range from ~500K to ~40M people. I want a smooth color gradient — light blue for low population, dark blue for high. What's the correct Mapbox GL JS expression pattern?",
+      "expectations": [
+        "Uses the interpolate expression with linear interpolation: ['interpolate', ['linear'], ['get', 'population'], ...]",
+        "Provides multiple stop values mapping population numbers to color values (at least 3-4 stops)",
+        "Shows the complete addLayer pattern with type 'fill' and the interpolate expression in fill-color paint property",
+        "Notes the alternative step expression for discrete buckets (e.g., ['step', ['get', 'population'], ...]) and when to prefer it over interpolate"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I want to highlight individual countries on hover on my choropleth map — change the color when the mouse enters a feature and reset when it leaves. I don't want to re-upload GeoJSON on every hover event. What's the efficient pattern?",
+      "expectations": [
+        "Use feature state: set generateId: true in the GeoJSON source definition",
+        "Call map.setFeatureState({ source: 'countries', id: hoveredId }, { hover: true }) on mousemove",
+        "Reset with map.setFeatureState({ source: 'countries', id: hoveredId }, { hover: false }) on mouseleave",
+        "Reference feature state in the layer paint with ['feature-state', 'hover'] expression (not re-uploading data)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I have 50MB of point data (millions of GPS records) I want to visualize on a Mapbox map. I tried loading it as GeoJSON but the map freezes on load. What's the right approach?",
+      "expectations": [
+        "50MB is well above the GeoJSON threshold — use vector tiles (MVT) instead",
+        "The rule: <1MB use GeoJSON, 1-10MB consider either, >10MB use vector tiles",
+        "Explains the source type change: type: 'vector' with a tiles URL, and requires source-layer in the addLayer call",
+        "Vector tiles support progressive loading — only tiles in the current viewport are fetched, not all 50MB at once"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds 3 evals for the mapbox-data-visualization-patterns skill
- Eval 1: Choropleth smooth color gradient with interpolate expression
- Eval 2: Hover highlight using feature state (no GeoJSON re-upload)
- Eval 3: 50MB GPS data performance — vector tiles vs GeoJSON

## Benchmark Results
- with_skill: 91.67% pass rate (mean)
- without_skill: 91.67% pass rate (mean)
- delta: +0.00pp

Note: Base model already knows choropleth interpolate and feature state patterns well from public Mapbox docs. Both configurations failed eval-3 expectation 2 (threshold rule table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)