### PR TITLE
Add Compose reference guide to mapbox-android-patterns

### DIFF
--- a/skills/mapbox-android-patterns/SKILL.md
+++ b/skills/mapbox-android-patterns/SKILL.md
@@ -384,6 +384,7 @@ mapView.mapboxMap.subscribeStyleLoaded { _ ->
 
 Load these references when you need detailed patterns for specific topics:
 
+- **`references/compose.md`** -- Jetpack Compose: dependencies, token setup, MapboxMap, annotations with click, GeoJSON, MapEffect
 - **`references/annotations.md`** -- Circle, Polyline, and Polygon annotation patterns
 - **`references/location-tracking.md`** -- Camera follow user location + get current location once
 - **`references/custom-data.md`** -- GeoJSON sources and layers: lines, polygons, points, update/remove

--- a/skills/mapbox-android-patterns/evals/evals.json
+++ b/skills/mapbox-android-patterns/evals/evals.json
@@ -30,6 +30,36 @@
         "To highlight, use setFeatureState on the building: mapView.mapboxMap.setFeatureState(building, StandardBuildingsState { highlight(true) })",
         "Notes that returning true from the lambda stops propagation to other interactions"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Add a Mapbox map to my Android Jetpack Compose project. I need the correct dependencies and a basic MapboxMap composable.",
+      "expectations": [
+        "Compose extension dependency uses group com.mapbox.extension, not com.mapbox.maps: implementation(\"com.mapbox.extension:maps-compose:11.x.x\")",
+        "Must NOT use com.mapbox.maps:compose, com.mapbox.maps:extension-compose, or com.mapbox.maps:android-compose",
+        "Both maps SDK and compose extension must use the same version",
+        "Uses MapboxMap composable from com.mapbox.maps.extension.compose, not AndroidView wrapping MapView"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I need to set the Mapbox access token programmatically in my Compose app before the map loads. What's the correct import and call?",
+      "expectations": [
+        "Import is from com.mapbox.common.MapboxOptions, NOT com.mapbox.maps.MapboxOptions",
+        "Call MapboxOptions.accessToken = \"pk.your_token\" before any map component is created",
+        "Recommends mapbox_access_token string resource as the preferred alternative",
+        "Must NOT use manifest <meta-data> placeholders with ${MAPBOX_ACCESS_TOKEN}"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "I want to add tappable point markers to my Mapbox Compose map. When a marker is tapped, I need to know which one was clicked. Show me the correct pattern.",
+      "expectations": [
+        "Uses PointAnnotation composable from com.mapbox.maps.extension.compose.annotation.generated",
+        "Uses interactionsState.onClicked { ... } inside the init lambda for tap handling, NOT the deprecated onClick parameter",
+        "Uses rememberIconImage(R.drawable.ic_marker) for the marker icon, not BitmapFactory",
+        "PointAnnotation renders nothing without iconImage — must always set it"
+      ]
     }
   ]
 }

--- a/skills/mapbox-android-patterns/references/compose.md
+++ b/skills/mapbox-android-patterns/references/compose.md
@@ -1,0 +1,117 @@
+# Jetpack Compose Integration
+
+Compose-specific patterns for Mapbox Maps SDK v11.
+
+## Dependencies
+
+```kotlin
+dependencies {
+    implementation("com.mapbox.maps:android:11.18.1")
+    implementation("com.mapbox.extension:maps-compose:11.18.1")
+}
+```
+
+Check [releases](https://github.com/mapbox/mapbox-maps-android/releases) for the latest version. Both artifacts must use the same version.
+
+The Compose extension group is `com.mapbox.extension`, NOT `com.mapbox.maps`.
+These do NOT exist: `com.mapbox.maps:compose`, `com.mapbox.maps:extension-compose`, `com.mapbox.maps:android-compose`, `com.mapbox.maps:maps-compose`.
+
+## Access Token
+
+Create `app/src/main/res/values/mapbox_access_token.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_access_token" translatable="false"
+        tools:ignore="UnusedResources">YOUR_MAPBOX_ACCESS_TOKEN</string>
+</resources>
+```
+
+The SDK reads this resource automatically. This is the recommended approach.
+
+To set the token programmatically, import from `com.mapbox.common` (NOT `com.mapbox.maps`):
+
+```kotlin
+import com.mapbox.common.MapboxOptions
+MapboxOptions.accessToken = "pk.your_token"
+```
+
+Do NOT use manifest `<meta-data>` placeholders — the SDK does not read tokens from `${MAPBOX_ACCESS_TOKEN}` in AndroidManifest.xml.
+
+## MapboxMap Composable
+
+```kotlin
+import com.mapbox.maps.extension.compose.MapboxMap
+import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.geojson.Point
+
+@Composable
+fun MapScreen() {
+    MapboxMap(
+        modifier = Modifier.fillMaxSize(),
+        mapViewportState = rememberMapViewportState {
+            setCameraOptions {
+                center(Point.fromLngLat(-122.4194, 37.7749))
+                zoom(12.0)
+            }
+        }
+    )
+}
+```
+
+`rememberMapViewportState` is in `com.mapbox.maps.extension.compose.animation.viewport`, not the root compose package.
+
+## Point Annotations
+
+```kotlin
+import com.mapbox.maps.extension.compose.annotation.generated.PointAnnotation
+import com.mapbox.maps.extension.compose.annotation.rememberIconImage
+
+@Composable
+fun MapWithMarkers() {
+    val markerIcon = rememberIconImage(R.drawable.ic_marker)
+
+    MapboxMap(modifier = Modifier.fillMaxSize(), mapViewportState = ...) {
+        PointAnnotation(point = Point.fromLngLat(lng, lat)) {
+            iconImage = markerIcon
+            interactionsState.onClicked { /* handle tap */ true }
+        }
+    }
+}
+```
+
+- `PointAnnotation` renders nothing without `iconImage` — always set it
+- Use `rememberIconImage(R.drawable.ic_marker)` for drawable resources
+- Use `interactionsState.onClicked { ... }` for tap handling (the `onClick` parameter is deprecated)
+- Annotation IDs are `Long`, not `String`
+
+## Loading GeoJSON from Assets
+
+```kotlin
+import com.mapbox.geojson.FeatureCollection
+import com.mapbox.geojson.Point
+
+val json = context.assets.open("data.geojson").bufferedReader().use { it.readText() }
+val features = FeatureCollection.fromJson(json).features() ?: emptyList()
+features.forEach { feature ->
+    val point = feature.geometry() as Point
+    val name = feature.getStringProperty("name")
+}
+```
+
+## MapEffect
+
+Use `MapEffect` for imperative style and layer operations (prefer `PointAnnotation` composable for markers):
+
+```kotlin
+import com.mapbox.maps.extension.compose.MapEffect
+
+MapboxMap(...) {
+    MapEffect(Unit) { mapView ->
+        // Style operations, custom layers, etc.
+    }
+}
+```
+
+Import is `com.mapbox.maps.extension.compose.MapEffect`, not `LaunchedEffect` from Compose runtime.


### PR DESCRIPTION
## Summary
Add `references/compose.md` to the `mapbox-android-patterns` skill — a focused Jetpack Compose reference addressing the top agent failure points discovered in readiness testing.

## Context
24 automated `claude -p` runs (Sonnet + Opus, with and without this plugin) revealed consistent patterns where agents fail to integrate Mapbox Maps SDK with Jetpack Compose. With the plugin, success rate improved from 25% to 67%, but 4 remaining failures are all addressable by better skill documentation.

## What this reference covers
- **Dependencies** — correct artifact (`com.mapbox.extension:maps-compose`) with explicit wrong variants to avoid
- **Access token** — string resource as recommended approach, `MapboxOptions` import from `com.mapbox.common` (not `com.mapbox.maps`), warning against manifest placeholders
- **MapboxMap composable** — setup with `rememberMapViewportState` and correct import path
- **Point annotations** — `rememberIconImage` for icons, `interactionsState.onClicked` for taps (not the deprecated `onClick` parameter), annotation ID type (Long)
- **GeoJSON loading** — `FeatureCollection.fromJson()` pattern for assets
- **MapEffect** — clarified for style/layer operations, not annotations

## Changes
- `skills/mapbox-android-patterns/references/compose.md` (new, 117 lines)
- `skills/mapbox-android-patterns/SKILL.md` — added compose.md to Reference Files list
- `skills/mapbox-android-patterns/evals/evals.json` — 3 new Compose evals (97% pass rate)

## Validation Results

Re-ran 12 tests with this PR's improved skill:

| Configuration | Functional | Rate |
|--------------|------------|------|
| Baseline (no plugin) | 3/12 | 25% |
| Old plugin (before this PR) | 8/12 | 67% |
| **This PR** | **11/12** | **92%** |

Opus: 6/6 (100%), Sonnet: 5/6 (83%). The only failure is a persistent Sonnet `MapEffect` wrong import path.

## Test Plan
- [x] Verify skill loads correctly with `claude --plugin-dir`
- [x] Run basic + stretch Compose prompts — 11/12 functional
- [x] Evals pass at 97% (70/72)