### PR TITLE
Harden skills for production resilience (agent benchmark)

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -120,6 +120,8 @@
     "recluster",
     "rerouting",
     "rgba",
+    "Scatterplot",
+    "ScatterplotLayer",
     "scroller",
     "searchbox",
     "smolagents",

--- a/skills/mapbox-android-patterns/SKILL.md
+++ b/skills/mapbox-android-patterns/SKILL.md
@@ -47,6 +47,14 @@ Create `app/res/values/mapbox_access_token.xml`:
 
 **Get your token:** Sign in at [mapbox.com](https://account.mapbox.com/access-tokens/)
 
+### Step 1b: Internet permission (required)
+
+Maps need network access. Include this in `AndroidManifest.xml` — agents often omit it and only list location permissions later:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
 ### Step 2: Add Maven Repository
 
 In `settings.gradle.kts`:
@@ -272,6 +280,7 @@ pointAnnotationManager.create(annotations)
 **Step 1: Add permissions to AndroidManifest.xml:**
 
 ```xml
+<uses-permission android:name="android.permission.INTERNET" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 ```

--- a/skills/mapbox-data-visualization-patterns/references/3d-extrusions.md
+++ b/skills/mapbox-data-visualization-patterns/references/3d-extrusions.md
@@ -99,7 +99,7 @@ map.on('load', () => {
 ]
 ```
 
-### Anti-pattern: constant extrusion height
+## Anti-pattern: constant extrusion height
 
 ```javascript
 // BAD — flat slabs are not data-driven 3D buildings

--- a/skills/mapbox-data-visualization-patterns/references/3d-extrusions.md
+++ b/skills/mapbox-data-visualization-patterns/references/3d-extrusions.md
@@ -98,3 +98,15 @@ map.on('load', () => {
   0.001  // Scale factor
 ]
 ```
+
+### Anti-pattern: constant extrusion height
+
+```javascript
+// BAD — flat slabs are not data-driven 3D buildings
+'fill-extrusion-height': 40
+
+// GOOD — expression from feature properties
+'fill-extrusion-height': ['get', 'height']
+```
+
+Agents often paste a constant height to “make 3D appear.” Prefer `['get', 'height']` (or an interpolate expression) whenever the challenge asks for data-driven extrusions.

--- a/skills/mapbox-geospatial-operations/SKILL.md
+++ b/skills/mapbox-geospatial-operations/SKILL.md
@@ -426,8 +426,7 @@ When generating browser demos against Mapbox REST APIs (not only MCP tools):
 const route = data.routes[0];
 // GOOD — meters / seconds from the API
 stats.textContent =
-  `Distance ${(route.distance / 1000).toFixed(2)} km · ` +
-  `Duration ${Math.round(route.duration / 60)} min`;
+  `Distance ${(route.distance / 1000).toFixed(2)} km · ` + `Duration ${Math.round(route.duration / 60)} min`;
 
 // BAD — cosmetic labels or hardcoded ETAs that look like a working demo
 // "Len 0.00 km · Time 2 min" / Math.round(120/60)

--- a/skills/mapbox-geospatial-operations/SKILL.md
+++ b/skills/mapbox-geospatial-operations/SKILL.md
@@ -416,6 +416,33 @@ Understanding what users mean:
 - Need route optimization
 - Need turn-by-turn directions
 
+## REST API honesty (Directions / Isochrone)
+
+When generating browser demos against Mapbox REST APIs (not only MCP tools):
+
+### Directions — use the route object metrics
+
+```javascript
+const route = data.routes[0];
+// GOOD — meters / seconds from the API
+stats.textContent =
+  `Distance ${(route.distance / 1000).toFixed(2)} km · ` +
+  `Duration ${Math.round(route.duration / 60)} min`;
+
+// BAD — cosmetic labels or hardcoded ETAs that look like a working demo
+// "Len 0.00 km · Time 2 min" / Math.round(120/60)
+```
+
+### Isochrone — request multiple contours when the prompt asks for bands
+
+```javascript
+// GOOD — three travel-time bands
+`contours_minutes=15,30,60`;
+
+// BAD — a single contour when the UX needs 15 / 30 / 60
+`contours_minutes=30`;
+```
+
 ## Integration with Other Skills
 
 **Works with:**

--- a/skills/mapbox-ios-patterns/SKILL.md
+++ b/skills/mapbox-ios-patterns/SKILL.md
@@ -124,6 +124,8 @@ class MapViewController: UIViewController {
 
 The SDK offers three ways to place a point on the map. Pick the simplest one that fits.
 
+**Agent note:** A SwiftUI Mapbox sketch is incomplete without at least one annotation (`Marker`, `PointAnnotation`, or `MapViewAnnotation`). Do not ship a bare `Map { }` with no pin.
+
 ### Which API should I use?
 
 | API                                                       | Use it when                                                                                    | Platforms       | Notes                                                                                                                                                                        |

--- a/skills/mapbox-search-patterns/SKILL.md
+++ b/skills/mapbox-search-patterns/SKILL.md
@@ -268,9 +268,7 @@ This applies to Mapbox Geocoding API v5 / Search Box in browser apps — not onl
 
 ```javascript
 // BAD — limit=1 without proximity can resolve "Lincoln Memorial" to Illinois
-fetch(
-  `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${token}&limit=1`
-);
+fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${token}&limit=1`);
 
 // GOOD — bias to map center (and optional bbox)
 fetch(
@@ -379,7 +377,7 @@ User query contains...
 5. **Requesting ETA unnecessarily** -> Adds API cost
 6. **Limit too high for UI** -> Overwhelming user
 7. **Not filtering types** -> Get cities when you want POIs
-8. **No debounce on typeahead** -> Quota burn and racey UI
+8. **No debounce on typeahead** -> Quota burn and racy UI
 
 ## Reference Files
 

--- a/skills/mapbox-search-patterns/SKILL.md
+++ b/skills/mapbox-search-patterns/SKILL.md
@@ -262,6 +262,25 @@ category_search_tool({
 });
 ```
 
+### Don't: Geocode ambiguous place names without proximity (REST too)
+
+This applies to Mapbox Geocoding API v5 / Search Box in browser apps — not only MCP tools.
+
+```javascript
+// BAD — limit=1 without proximity can resolve "Lincoln Memorial" to Illinois
+fetch(
+  `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${token}&limit=1`
+);
+
+// GOOD — bias to map center (and optional bbox)
+fetch(
+  `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json` +
+    `?access_token=${token}&proximity=-77.0369,38.9072&bbox=-77.15,38.79,-76.90,38.99&limit=1`
+);
+```
+
+Also debounce search inputs (`clearTimeout` + `setTimeout`) so every keystroke does not fire a geocode.
+
 ### Don't: Use bbox when you mean proximity
 
 ```javascript
@@ -353,13 +372,14 @@ User query contains...
 
 ## Common Mistakes
 
-1. **Forgetting proximity** -> Results are global/IP-based
+1. **Forgetting proximity** -> Results are global/IP-based (or wrong state for ambiguous memorial/park names)
 2. **Using wrong tool** -> category_search for "Starbucks" (use search_and_geocode)
 3. **Invalid category** -> Check category_list first
 4. **Bbox too small** -> No results; use proximity instead
 5. **Requesting ETA unnecessarily** -> Adds API cost
 6. **Limit too high for UI** -> Overwhelming user
 7. **Not filtering types** -> Get cities when you want POIs
+8. **No debounce on typeahead** -> Quota burn and racey UI
 
 ## Reference Files
 

--- a/skills/mapbox-style-patterns/SKILL.md
+++ b/skills/mapbox-style-patterns/SKILL.md
@@ -188,27 +188,6 @@ This skill provides battle-tested style patterns and layer configurations for co
 }
 ```
 
-## Survive setStyle (critical)
-
-`map.setStyle(...)` replaces the style tree. Custom sources/layers/handlers added earlier are wiped unless you re-attach them.
-
-```javascript
-function onStyleReady() {
-  // re-add sources, layers, and interaction handlers here
-}
-
-map.on('style.load', onStyleReady);
-
-document.querySelectorAll('[data-style]').forEach((btn) => {
-  btn.addEventListener('click', () => {
-    map.setStyle(btn.dataset.style);
-    // do NOT only add layers on the first 'load' — wait for style.load after every switch
-  });
-});
-```
-
-**Agent anti-pattern:** style switcher buttons that call `setStyle` once with no `style.load` rebind. The first style works; every switch after looks broken.
-
 ## Reference Files
 
 Additional patterns and configurations are available in the `references/` directory. Load the relevant file when a specific pattern is needed.

--- a/skills/mapbox-style-patterns/SKILL.md
+++ b/skills/mapbox-style-patterns/SKILL.md
@@ -188,6 +188,27 @@ This skill provides battle-tested style patterns and layer configurations for co
 }
 ```
 
+## Survive setStyle (critical)
+
+`map.setStyle(...)` replaces the style tree. Custom sources/layers/handlers added earlier are wiped unless you re-attach them.
+
+```javascript
+function onStyleReady() {
+  // re-add sources, layers, and interaction handlers here
+}
+
+map.on('style.load', onStyleReady);
+
+document.querySelectorAll('[data-style]').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    map.setStyle(btn.dataset.style);
+    // do NOT only add layers on the first 'load' — wait for style.load after every switch
+  });
+});
+```
+
+**Agent anti-pattern:** style switcher buttons that call `setStyle` once with no `style.load` rebind. The first style works; every switch after looks broken.
+
 ## Reference Files
 
 Additional patterns and configurations are available in the `references/` directory. Load the relevant file when a specific pattern is needed.

--- a/skills/mapbox-token-security/SKILL.md
+++ b/skills/mapbox-token-security/SKILL.md
@@ -244,7 +244,7 @@ MAPBOX_SECRET_TOKEN=sk.ey...
 
 **Example: Safe Client Usage (Vite):**
 
-> **Note:** This example uses **Vite**. For Next.js, CRA, Angular, or a plain `window.MAPBOX_ACCESS_TOKEN` / CDN setup, see [Token Management Patterns](../mapbox-web-integration-patterns/references/token-management.md). Do not chain `import.meta.env` and `process.env` in one expression — the unused path throws `ReferenceError` in the browser.
+> **Note:** This example uses **Vite**. For Next.js, CRA, Angular, or a plain `window.MAPBOX_ACCESS_TOKEN` / CDN setup, see [Token Management](references/token-management.md). Do not chain `import.meta.env` and `process.env` in one expression — the unused path throws `ReferenceError` in the browser.
 
 ```javascript
 // Public token with URL restrictions - SAFE (Vite)
@@ -307,6 +307,7 @@ Agents often assign `mapboxgl.accessToken` and call `new mapboxgl.Map(...)` with
 
 For detailed guidance on specific topics, load these references as needed:
 
+- **`references/token-management.md`** — Bundler-specific env var names and access patterns (Vite / Next / CRA / Angular / CDN). Load when: wiring tokens in a different framework than the Vite example above.
 - **`references/rotation-monitoring.md`** — Token rotation strategies (zero-downtime + emergency), monitoring metrics, alerting rules, and monthly/quarterly audit checklists. Load when: implementing rotation, setting up monitoring, or conducting audits.
 - **`references/incident-response.md`** — Step-by-step incident response plan and common security mistakes with code examples. Load when: responding to a token compromise, reviewing code for security issues, or training on anti-patterns.
 

--- a/skills/mapbox-token-security/SKILL.md
+++ b/skills/mapbox-token-security/SKILL.md
@@ -242,18 +242,17 @@ MAPBOX_SECRET_TOKEN=sk.ey...
 - Share tokens between unrelated apps
 - Use tokens with excessive scopes
 
-**Example: Safe Client Usage:**
+**Example: Safe Client Usage (Vite):**
+
+> **Note:** This example uses **Vite**. For Next.js, CRA, Angular, or a plain `window.MAPBOX_ACCESS_TOKEN` / CDN setup, see [Token Management Patterns](../mapbox-web-integration-patterns/references/token-management.md). Do not chain `import.meta.env` and `process.env` in one expression — the unused path throws `ReferenceError` in the browser.
 
 ```javascript
-// Public token with URL restrictions - SAFE
-const mapboxToken =
-  window.MAPBOX_ACCESS_TOKEN ||
-  import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ||
-  process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+// Public token with URL restrictions - SAFE (Vite)
+const mapboxToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN;
 
 // Guard BEFORE constructing the map — missing tokens otherwise yield a silent blank map
 if (!mapboxToken || mapboxToken === 'YOUR_MAPBOX_ACCESS_TOKEN') {
-  throw new Error('Missing MAPBOX_ACCESS_TOKEN — set it in env / config before creating the map');
+  throw new Error('Missing VITE_MAPBOX_ACCESS_TOKEN — set it in env before creating the map');
 }
 
 mapboxgl.accessToken = mapboxToken;
@@ -265,7 +264,7 @@ Agents often assign `mapboxgl.accessToken` and call `new mapboxgl.Map(...)` with
 
 **Always:**
 
-1. Resolve the token from env / `window.MAPBOX_ACCESS_TOKEN` / config (never hardcode a real `pk.` in source)
+1. Resolve the token from the env pattern for your bundler (never hardcode a real `pk.` in source)
 2. Validate it is present and not a placeholder
 3. Only then set `accessToken` and construct the map
 

--- a/skills/mapbox-token-security/SKILL.md
+++ b/skills/mapbox-token-security/SKILL.md
@@ -246,12 +246,28 @@ MAPBOX_SECRET_TOKEN=sk.ey...
 
 ```javascript
 // Public token with URL restrictions - SAFE
-const mapboxToken = 'pk.YOUR_MAPBOX_TOKEN_HERE';
+const mapboxToken =
+  window.MAPBOX_ACCESS_TOKEN ||
+  import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ||
+  process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
-// This token is restricted to your domain
-// and only has styles:read scope
+// Guard BEFORE constructing the map — missing tokens otherwise yield a silent blank map
+if (!mapboxToken || mapboxToken === 'YOUR_MAPBOX_ACCESS_TOKEN') {
+  throw new Error('Missing MAPBOX_ACCESS_TOKEN — set it in env / config before creating the map');
+}
+
 mapboxgl.accessToken = mapboxToken;
 ```
+
+### Agent anti-pattern: skip the token guard
+
+Agents often assign `mapboxgl.accessToken` and call `new mapboxgl.Map(...)` with no check. That fails closed as a blank canvas with no UI error.
+
+**Always:**
+
+1. Resolve the token from env / `window.MAPBOX_ACCESS_TOKEN` / config (never hardcode a real `pk.` in source)
+2. Validate it is present and not a placeholder
+3. Only then set `accessToken` and construct the map
 
 ## Security Checklist
 
@@ -270,6 +286,7 @@ mapboxgl.accessToken = mapboxToken;
 - [ ] Rotate tokens every 90 days (or per policy)
 - [ ] Remove unused tokens promptly
 - [ ] Separate tokens by environment (dev/staging/prod)
+- [ ] Guard missing tokens in client code before `new mapboxgl.Map`
 
 **Monitoring:**
 

--- a/skills/mapbox-token-security/references/token-management.md
+++ b/skills/mapbox-token-security/references/token-management.md
@@ -1,0 +1,13 @@
+# Token Management (bundler env patterns)
+
+Use **one** env access pattern per app. Do not chain `import.meta.env`, `process.env`, and `window.*` in a single expression — unused identifiers throw `ReferenceError` in the browser before your token guard runs.
+
+| Framework/Bundler    | Environment Variable            | Access Pattern                             |
+| -------------------- | ------------------------------- | ------------------------------------------ |
+| **Vite**             | `VITE_MAPBOX_ACCESS_TOKEN`      | `import.meta.env.VITE_MAPBOX_ACCESS_TOKEN` |
+| **Next.js**          | `NEXT_PUBLIC_MAPBOX_TOKEN`      | `process.env.NEXT_PUBLIC_MAPBOX_TOKEN`     |
+| **Create React App** | `REACT_APP_MAPBOX_TOKEN`        | `process.env.REACT_APP_MAPBOX_TOKEN`       |
+| **Angular**          | `environment.mapboxAccessToken` | Environment files (`environment.ts`)       |
+| **Plain HTML / CDN** | (config script)                 | `window.MAPBOX_ACCESS_TOKEN`               |
+
+For framework lifecycle examples, also see the **mapbox-web-integration-patterns** skill.

--- a/skills/mapbox-web-integration-patterns/SKILL.md
+++ b/skills/mapbox-web-integration-patterns/SKILL.md
@@ -317,6 +317,41 @@ export default {
 
 **Why:** In Vue (especially Vue 3), `data()` properties are wrapped in a `Proxy` for reactivity. Mapbox GL JS internally checks object identity and uses properties that don't survive proxy wrapping. Storing the map in `data()` causes subtle, hard-to-debug failures. Instead, assign the map instance directly as `this.map` in `mounted()` — properties assigned outside `data()` are not made reactive.
 
+### Mistake 5: Silent style/tile failures (no error handler)
+
+```javascript
+// BAD — blank map when the token/style fails
+const map = new mapboxgl.Map({ ... });
+
+// GOOD — surface failures
+map.on('error', (e) => {
+  console.error(e.error || e);
+  // optionally show an on-page error message
+});
+```
+
+### Mistake 6: Broken deck.gl CDN via jsDelivr `+esm`
+
+```html
+<!-- BAD — often throws: does not provide export named 'makeBatchFromTable' -->
+<script type="module">
+  import { MapboxOverlay } from 'https://cdn.jsdelivr.net/npm/@deck.gl/mapbox@9.0.0/+esm';
+</script>
+
+<!-- GOOD — UMD bundle (or esm.sh) -->
+<script src="https://unpkg.com/deck.gl@9.1.14/dist.min.js"></script>
+<script>
+  const { MapboxOverlay, ScatterplotLayer } = deck;
+  map.addControl(new MapboxOverlay({ interleaved: false, layers: [/* ... */] }));
+</script>
+```
+
+Use `MapboxOverlay` (Mapbox IControl), not a bare `Deck` as a map control.
+
+### Mistake 7: Draw toolbar without `draw.create`
+
+If you load `mapbox-gl-draw`, listen for `draw.create` (and update the UI from `draw.getAll()`). Half-deleted handlers that leave a dangling `});` crash the page.
+
 ## Reference Files
 
 Load these for framework-specific patterns and additional details:

--- a/skills/mapbox-web-integration-patterns/SKILL.md
+++ b/skills/mapbox-web-integration-patterns/SKILL.md
@@ -342,7 +342,14 @@ map.on('error', (e) => {
 <script src="https://unpkg.com/deck.gl@9.1.14/dist.min.js"></script>
 <script>
   const { MapboxOverlay, ScatterplotLayer } = deck;
-  map.addControl(new MapboxOverlay({ interleaved: false, layers: [/* ... */] }));
+  map.addControl(
+    new MapboxOverlay({
+      interleaved: false,
+      layers: [
+        /* ... */
+      ]
+    })
+  );
 </script>
 ```
 

--- a/skills/mapbox-web-integration-patterns/SKILL.md
+++ b/skills/mapbox-web-integration-patterns/SKILL.md
@@ -352,6 +352,27 @@ Use `MapboxOverlay` (Mapbox IControl), not a bare `Deck` as a map control.
 
 If you load `mapbox-gl-draw`, listen for `draw.create` (and update the UI from `draw.getAll()`). Half-deleted handlers that leave a dangling `});` crash the page.
 
+### Mistake 8: Layers lost after `setStyle` (no `style.load` rebind)
+
+`map.setStyle(...)` replaces the style tree. Custom sources/layers/handlers added earlier are wiped unless you re-attach them.
+
+```javascript
+function onStyleReady() {
+  // re-add sources, layers, and interaction handlers here
+}
+
+map.on('style.load', onStyleReady);
+
+document.querySelectorAll('[data-style]').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    map.setStyle(btn.dataset.style);
+    // do NOT only add layers on the first 'load' — wait for style.load after every switch
+  });
+});
+```
+
+**Agent anti-pattern:** style switcher buttons that call `setStyle` once with no `style.load` rebind. The first style works; every switch after looks broken.
+
 ## Reference Files
 
 Load these for framework-specific patterns and additional details:

--- a/skills/mapbox-web-performance-patterns/SKILL.md
+++ b/skills/mapbox-web-performance-patterns/SKILL.md
@@ -295,12 +295,18 @@ When building a Mapbox application, verify these optimizations in order:
 
 ### 🟡 High Impact
 
-- [ ] Debounce/throttle map event handlers
+- [ ] Debounce/throttle map event handlers (geocode inputs, `moveend`)
 - [ ] Optimize queryRenderedFeatures with layers filter and bounding box
 - [ ] Use GeoJSON for < 5 MB, vector tiles for > 20 MB
-- [ ] Always call map.remove() on cleanup in SPAs
+- [ ] Always call map.remove() on cleanup in SPAs / page teardown
+- [ ] Attach `map.on('error', …)` (or visible error UI) so style/tile/token failures are not silent
 - [ ] Reuse popup instances (don't create on every interaction)
 - [ ] Use feature state instead of dynamic layers for hover/selection
+- [ ] Cluster demos: generate enough points to stress clustering (thousands, not a few hundred)
+
+### Agent anti-pattern: happy-path only
+
+First-pass agent code often ships a map with no `map.on('error')`, no `map.remove()`, and a tiny point set that never exercises `cluster: true`. Production demos need error visibility, teardown, and realistic scale.
 
 ### 🟢 Optimization
 


### PR DESCRIPTION
﻿## Summary

I'm new to agent/AI coding and built a small Mapbox playground to learn how agents actually behave with mapbox-agent-skills — same four-pack idea as my MapTiler lab (no skill → skill → improved → upload). Great work getting the agent skills off the ground.

I graded the same 22 challenges three ways (harsh mode):

| Set | Avg |
|-----|----:|
| No skill | ~79% |
| Current skill | ~90% |
| **This revision** | **~100%** |

That run showed recurring failure modes. This PR hardens the skills below so agents get clearer guidance on those gaps.

Live grader: https://witcoskitech.com/mapbox-playground/agent-grader.html

## Problems it fixes

1. **Missing token guard** — blank map when `MAPBOX_ACCESS_TOKEN` unset / placeholder
2. **No `map.on('error')`** — silent style/tile/token failures
3. **No teardown** — missing `map.remove()` on SPA/page cleanup
4. **Layers lost on `setStyle()`** — no `style.load` rebind (now under web-integration-patterns)
5. **Geocode without proximity** — ambiguous places resolve wrong (REST + debounce)
6. **Fake Directions metrics** — cosmetic "Len/Time" instead of `route.distance` / `route.duration`
7. **Single-band isochrones** — one contour when UX needs 15/30/60
8. **Broken deck.gl CDN** — jsDelivr `+esm` vs stable UMD / `MapboxOverlay`
9. **Draw without `draw.create`** — toolbar present, handler missing/broken
10. **Constant extrusion height** — not data-driven `['get', 'height']`
11. **Native gaps** — bare iOS `Map { }` with no annotation; Android missing `INTERNET`

## Files

- `mapbox-token-security`
- `mapbox-web-performance-patterns`
- `mapbox-search-patterns`
- `mapbox-geospatial-operations`
- `mapbox-web-integration-patterns`
- `mapbox-data-visualization-patterns/references/3d-extrusions.md`
- `mapbox-ios-patterns`
- `mapbox-android-patterns`

## Test plan

- [ ] Review each added anti-pattern / checklist item in the files above
- [ ] Spot-check agents following the updated skills: token guard before `new Map`, `map.on('error')`, `style.load` after `setStyle`
- [ ] Confirm Directions/Isochrone and deck.gl guidance match production CDN/API usage
