### PR TITLE
Fix eval.js default model: claude-sonnet-4-20250514 has been retired

### DIFF
--- a/scripts/eval.js
+++ b/scripts/eval.js
@@ -18,8 +18,8 @@ if (existsSync('.env')) {
 
 const anthropic = new Anthropic();
 
-const MODEL = process.env.EVAL_MODEL || 'claude-sonnet-4-20250514';
-const JUDGE_MODEL = process.env.EVAL_JUDGE_MODEL || 'claude-sonnet-4-20250514';
+const MODEL = process.env.EVAL_MODEL || 'claude-sonnet-5';
+const JUDGE_MODEL = process.env.EVAL_JUDGE_MODEL || 'claude-sonnet-5';
 const CONCURRENCY = parseInt(process.env.EVAL_CONCURRENCY || '10', 10);
 const SKILLS_DIR = 'skills';
 


### PR DESCRIPTION
## Summary

`npm run eval` was failing for everyone (not just one person's setup) with:

```
Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

`scripts/eval.js` hardcodes `claude-sonnet-4-20250514` as the default for both `EVAL_MODEL` and
`EVAL_JUDGE_MODEL`. That model has since been retired by the API, so `npm run eval <skill>` 404s
for anyone who doesn't already know to override it via env var.

## Fix

Default both to `claude-sonnet-5` instead. Still fully overridable via `EVAL_MODEL` /
`EVAL_JUDGE_MODEL` env vars, so this doesn't remove any flexibility, it just fixes the
out-of-the-box default.

## Test plan

- [x] `npm run eval mapbox-token-security` runs successfully with no env var override, scores 44/45 (97.8%)
- [x] `npm run check` passes (format, spellcheck, markdown lint, skill validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)